### PR TITLE
Added the option to invert the Inflow and Outflow column data when the same column is mapped

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,6 +33,7 @@
       <div class='container'>
         <!-- <h1>YNAB CSV</h1> -->
         <div class='pull-right' ng-if='data_object.base_json'>
+		  <div ng-show="ynab_map['Inflow'] == ynab_map['Outflow']" class='btn btn-default' ng-click='invert_flows()'><i class='fa fa-exchange'></i> Invert flows</div>
           <div class='btn btn-default' ng-click='reloadApp()'><i class='fa fa-refresh'></i> Load a different file</div>
           <div class='btn btn-primary' ng-click='downloadFile()'><i class='fa fa-cloud-download'></i> Save YNAB Data</div>
         </div>

--- a/src/app.js
+++ b/src/app.js
@@ -101,6 +101,7 @@ angular.element(document).ready(function() {
         Outflow: "Outflow",
         Inflow: "Inflow"
       };
+	  $scope.inverted_outflow = false;
       $scope.file = {
         encodings: encodings,
         chosenEncoding: localStorage.getItem('chosenEncoding') || "UTF-8"
@@ -116,21 +117,29 @@ angular.element(document).ready(function() {
     $scope.$watch("data.source", function(newValue, oldValue) {
       if (newValue && newValue.length > 0) {
         $scope.data_object.parse_csv(newValue, $scope.file.chosenEncoding);
-        $scope.preview = $scope.data_object.converted_json(10, $scope.ynab_map);
+        $scope.preview = $scope.data_object.converted_json(10, $scope.ynab_map, $scope.inverted_outflow);
+      }
+    });
+	$scope.$watch("inverted_outflow", function(newValue, oldValue) {
+      if (newValue != oldValue) {
+        $scope.preview = $scope.data_object.converted_json(10, $scope.ynab_map, $scope.inverted_outflow);
       }
     });
     $scope.$watch(
       "ynab_map",
       function(newValue, oldValue) {
-        $scope.preview = $scope.data_object.converted_json(10, newValue);
+        $scope.preview = $scope.data_object.converted_json(10, newValue, $scope.inverted_outflow);
       },
       true
     );
     $scope.csvString = function() {
-      return $scope.data_object.converted_csv(null, $scope.ynab_map);
+      return $scope.data_object.converted_csv(null, $scope.ynab_map, $scope.inverted_outflow);
     };
     $scope.reloadApp = function() {
       $scope.setInitialScopeState();
+    }
+	$scope.invert_flows = function() {
+      $scope.inverted_outflow = !$scope.inverted_outflow;
     }
     $scope.downloadFile = function() {
       var a;


### PR DESCRIPTION
There might be a pull request for the same purpose on the hallofffame repo, but their sample link did not look to work.

Anyway, my bank recently made CSV format the only export option and bill payments were signified as a negative amount while charges were positive.  With the current version of your fork as linked from the YNAB 4 official documentation, this means charges are considered Inflows while payments were Outflows.

This change results in the presence of an "Invert flows" button when the Outflow and Inflow columns are mapped to the same value.  Clicking on it will place charges and payments under the correct column for my bank.