### PR TITLE
Add http-server for cross-platform compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "server.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "open http://localhost:3000/ && node server.js",
+    "start": "http-server --port 3000 -o",
     "bs": "browser-sync . -w"
   },
   "repository": {
@@ -26,6 +26,7 @@
   },
   "homepage": "https://github.com/aniav/ynab-csv",
   "devDependencies": {
-    "browser-sync": "^2.29.3"
+    "browser-sync": "^2.29.3",
+    "http-server": "^14.1.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -16,9 +16,6 @@
     "ynab",
     "csv"
   ],
-  "dependencies": {
-    "express": "^4.18.2"
-  },
   "author": "Ryan Hall",
   "license": "MIT",
   "bugs": {
@@ -26,7 +23,7 @@
   },
   "homepage": "https://github.com/aniav/ynab-csv",
   "devDependencies": {
-    "browser-sync": "^2.29.3",
+    "browser-sync": "^3.0.2",
     "http-server": "^14.1.1"
   }
 }

--- a/server.js
+++ b/server.js
@@ -1,7 +1,0 @@
-var express = require('express');
-var app = express();
-
-app.use(express.static(__dirname));
-
-app.listen(process.env.PORT || 3000);
-console.log('Server running at http://localhost:3000/');


### PR DESCRIPTION
Issue: The NPM start script uses the `open` command which is specific to MacOS.

Rather than use a platform-specific command to launch the browser, the [http-server](https://www.npmjs.com/package/http-server) package can do this instead in a way that works for all platforms. This would allow all users to run `npm start` in the terminal to launch the app.