### PR TITLE
Invert negative inflow

### DIFF
--- a/src/data_object.js
+++ b/src/data_object.js
@@ -106,7 +106,7 @@ window.DataObject = class DataObject {
                       tmp_row[col] = cell.startsWith('-') ? cell.slice(1) : "";
                     }
                   } else {
-                    tmp_row[col] = cell;
+                    tmp_row[col] = cell.startsWith('-') ? cell.slice(1) : cell;
                   }
                   break;
                 default:


### PR DESCRIPTION
This will invert negative values in the inflow column, the same as is done for outflow. When there are separate inflow vs outflow columns, there's no need for negative values because a negative value would appear in the other column.

Citi credit cards export data in this format (inflow/outflow separate, inflow is negative). Here is an example CSV demonstrating what Citi would export.

[citi_example.CSV](https://github.com/user-attachments/files/18759478/citi_example.CSV)
